### PR TITLE
Add latest tags to Anthropic models

### DIFF
--- a/letta/llm_api/anthropic.py
+++ b/letta/llm_api/anthropic.py
@@ -53,6 +53,11 @@ MODEL_LIST = [
         "name": "claude-3-opus-20240229",
         "context_window": 200000,
     },
+    # latest
+    {
+        "name": "claude-3-opus-latest",
+        "context_window": 200000,
+    },
     ## Sonnet
     # 3.0
     {
@@ -69,9 +74,19 @@ MODEL_LIST = [
         "name": "claude-3-5-sonnet-20241022",
         "context_window": 200000,
     },
+    # 3.5 latest
+    {
+        "name": "claude-3-5-sonnet-latest",
+        "context_window": 200000,
+    },
     # 3.7
     {
         "name": "claude-3-7-sonnet-20250219",
+        "context_window": 200000,
+    },
+    # 3.7 latest
+    {
+        "name": "claude-3-7-sonnet-latest",
         "context_window": 200000,
     },
     ## Haiku
@@ -83,6 +98,11 @@ MODEL_LIST = [
     # 3.5
     {
         "name": "claude-3-5-haiku-20241022",
+        "context_window": 200000,
+    },
+    # 3.5 latest
+    {
+        "name": "claude-3-5-haiku-latest",
         "context_window": 200000,
     },
 ]


### PR DESCRIPTION
This PR adds in the "latest" tags from https://docs.anthropic.com/en/docs/about-claude/models/all-models so that they are available from the dropdown list.  This is useful because the model list is hardcoded and so a dated tag may lag behind when Anthropic has new releases.

**How to test**

You should see the "latest" tag for appropriate models.

**Have you tested this PR?**

I have not.
